### PR TITLE
fix(cli): add MIT license and optimize property handling

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,6 +6,7 @@
 	"type": "module",
 	"scripts": {},
 	"author": "star-ll",
+	"license": "MIT",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/star-ll/deco.git",

--- a/packages/renderer/src/patch/props.ts
+++ b/packages/renderer/src/patch/props.ts
@@ -58,10 +58,7 @@ function handleOtherProps(element: HTMLElement, propName: string, value: unknown
 	} else {
 		try {
 			if (propName in element) {
-				const description = Object.getOwnPropertyDescriptor(element, propName);
-				if (!description || description.writable) {
-					changeElemenProp(element, propName, value);
-				}
+				changeElemenProp(element, propName, value);
 				element.setAttribute(propName, String(value));
 			} else {
 				element.setAttribute(propName, String(value));


### PR DESCRIPTION
- Add MIT license to package.json
- Simplify property handling in renderer:
  - Remove unnecessary descriptor check
  - Always attempt to set property and attribute