### PR TITLE
v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+    # Changelog
+
+    ## [0.3.5] - 2025-01-18
+
+    ### Changed
+
+    - '@Store' decorator is deprecated. Use '@UseStore' instead.
+    - Fix Store error when using `@UseStore` decorator in nested object.
+    - Optimize deep reactive: only writable properties are deeply make reactive.
+    - Change `@UseStore` decorator example.

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
 	"$schema": "node_modules/lerna/schemas/lerna-schema.json",
-	"version": "0.3.4",
+	"version": "0.3.5",
 	"npmClient": "pnpm"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@decoco/core",
-	"version": "0.3.4",
+	"version": "0.3.5",
 	"description": "decoco is an efficient Web Component framework based on decorator-driven development",
 	"main": "./dist/index.esm.dev.js",
 	"types": "./dist/index.d.ts",

--- a/packages/core/src/decorators/UseStore.ts
+++ b/packages/core/src/decorators/UseStore.ts
@@ -1,4 +1,4 @@
-export default function Store(store: any, getState: (state: any) => any) {
+export default function UseStore(store: any, getState: (state: any) => any) {
 	return function (target: any, propertyName: string) {
 		const storeMap = Reflect.getMetadata('stores', target) || new Map();
 		storeMap.set(propertyName, { store, getState });

--- a/packages/core/src/decorators/index.ts
+++ b/packages/core/src/decorators/index.ts
@@ -4,9 +4,9 @@ import State from './State';
 import Computed from './Computed';
 import Watch from './Watch';
 import Ref, { RefType } from './Ref';
-import Store from './Store';
+import UseStore from './UseStore';
 import { Event, Listen, type EventEmitter as EventEmitterType } from './Event';
 
 type EventEmitter = EventEmitterType | undefined;
 
-export { Component, Prop, State, Computed, Watch, Ref, Event, Listen, Store, type EventEmitter, type RefType };
+export { Component, Prop, State, Computed, Watch, Ref, Event, Listen, UseStore, type EventEmitter, type RefType };

--- a/packages/core/src/reactive/observe.ts
+++ b/packages/core/src/reactive/observe.ts
@@ -56,8 +56,11 @@ export function createReactive(targetElement: any, target: unknown, options: Obs
 
 	if (deep) {
 		for (const key of Object.keys(target)) {
-			const value = target[key as keyof typeof target];
-			(target[key as keyof typeof target] as any) = createReactive(targetElement, value, options);
+			const descriptor = Object.getOwnPropertyDescriptor(target, key);
+			if (!descriptor || descriptor?.writable) {
+				const value = target[key as keyof typeof target];
+				(target[key as keyof typeof target] as any) = createReactive(targetElement, value, options);
+			}
 		}
 	}
 
@@ -70,7 +73,7 @@ export function createReactive(targetElement: any, target: unknown, options: Obs
  * change prop only method
  */
 let escapePropSealFlag = false;
-export function escapePropSet(target: any, prop: string, value: any) {
+export function escapePropSet(target: any, prop: string | symbol, value: any) {
 	escapePropSealFlag = true;
 	target[prop] = value;
 	escapePropSealFlag = false;

--- a/packages/docs/docs/guide/decorators/Event.md
+++ b/packages/docs/docs/guide/decorators/Event.md
@@ -42,6 +42,11 @@ export class EmitEvent extends DecoElement {
 | eventName | string | 事件名 |
 | data      | any | 事件数据 |
 
+## 事件冒泡
+
+默认情况下，composed和bubbles会被设置为true以便事件可以向上冒泡，这意味着子孙组件一旦发送事件，其父组件以及所有祖先节点都会收到事件，除非事件冒泡过程中通过`e.stopPropagation()`阻止事件冒泡。这一行为与传统框架不同，需要特别注意不要重复发送事件。
+
+
 # Listen
 
 ## 基本用法

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@decoco/docs",
-	"version": "0.3.4",
+	"version": "0.3.5",
 	"private": true,
 	"description": "Docs for Decoco",
 	"scripts": {

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@decoco/examples",
 	"private": "true",
-	"version": "0.3.4",
+	"version": "0.3.5",
 	"description": "",
 	"main": "index.js",
 	"author": "",

--- a/packages/examples/src/api/store.tsx
+++ b/packages/examples/src/api/store.tsx
@@ -1,5 +1,5 @@
 import { configureStore, createSlice } from '@reduxjs/toolkit';
-import { DecoElement, Component, Store } from '@decoco/core';
+import { DecoElement, Component, UseStore } from '@decoco/core';
 
 const testSlice = createSlice({
 	name: 'test',
@@ -24,7 +24,7 @@ function incrementCount() {
 
 @Component('test-base-store')
 export class TestBaseStore extends DecoElement {
-	@Store(store, (state: RootState) => state.test) store!: RootState['test'];
+	@UseStore(store, (state: RootState) => state.test) store!: RootState['test'];
 
 	componentDidMount(): void {
 		incrementCount();
@@ -53,7 +53,7 @@ export class TestBaseStore extends DecoElement {
 
 @Component('test-base-store-child')
 export class TestBaseStoreChild extends DecoElement {
-	@Store(store, (state: RootState) => state.test) store!: RootState['test'];
+	@UseStore(store, (state: RootState) => state.test) store!: RootState['test'];
 
 	render(): JSX.Element | void {
 		const { dispatch } = store;

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@decoco/renderer",
-	"version": "0.3.4",
+	"version": "0.3.5",
 	"description": "A vital component of the Decoco framework, responsible for rendering elements to the DOM",
 	"main": "dist/esm/index.js",
 	"type": "module",


### PR DESCRIPTION
- '@Store' decorator is deprecated. Use '@UseStore' instead.
- Fix Store error when using `@UseStore` decorator in nested object.
- Optimize deep reactive: only writable properties are deeply make reactive.
- Change `@UseStore` decorator example.